### PR TITLE
「wordset_exclude」に「ama」を追加

### DIFF
--- a/wordset_exclude.txt
+++ b/wordset_exclude.txt
@@ -3,3 +3,4 @@ AAA
 lento
 ita
 ada
+ama


### PR DESCRIPTION
`toyama` とかをローマ字読みしてしまっていたので、 `ama` を `wordset_exclude.txt` へ追加しました。
何か不都合があれば、拒否してもらって結構です。
