### PR TITLE
 wordset_exclude.txt に追加されていたのを修正

### DIFF
--- a/wordset_additional.txt
+++ b/wordset_additional.txt
@@ -51,3 +51,15 @@ offense
 utilize
 dialogue
 ufo
+gocache
+aaaa
+caa
+soa
+gae
+metadata
+mydomain
+myorigin
+inzone
+enquete
+iaea
+uae

--- a/wordset_exclude.txt
+++ b/wordset_exclude.txt
@@ -7,17 +7,5 @@ ama
 taro
 muumuu
 ken
-gocache
 nda
-aaaa
-caa
-soa
-gae
 sen
-metadata
-mydomain
-myorigin
-inzone
-enquete
-iaea
-uae


### PR DESCRIPTION
#43 のPRですが、こちらのミスで `wordset_additional.txt` に追加すべき単語を `wordset_exclude.txt` に追加してしまっていました。
これを修正しています。
